### PR TITLE
Added link to the p4js.org examples to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can see many examples in the
 [examples/](https://github.com/joakin/elm-canvas/tree/master/examples) folder,
 and experience them [live](https://joakin.github.io/elm-canvas).
 
-Additinally, some of the [p5js.org examples](https://p5js.org/examples/) where adopted to Elm using this package. They can be found [here](https://discourse.elm-lang.org/t/some-p5js-org-examples-in-elm/3781).
+Additionally, some of the [p5js.org examples](https://p5js.org/examples/) were adapted to Elm using this package. They can be found [here](https://discourse.elm-lang.org/t/some-p5js-org-examples-in-elm/3781).
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You can see many examples in the
 [examples/](https://github.com/joakin/elm-canvas/tree/master/examples) folder,
 and experience them [live](https://joakin.github.io/elm-canvas).
 
+Additinally, some of the [p5js.org examples](https://p5js.org/examples/) where adopted to Elm using this package. They can be found [here](https://discourse.elm-lang.org/t/some-p5js-org-examples-in-elm/3781).
+
 ```
 
 ```


### PR DESCRIPTION
As discussed in the [corresponding discourse thread](https://discourse.elm-lang.org/t/some-p5js-org-examples-in-elm/3781), I've added the link to the bottom of the readme.