### PR TITLE
add comment for arc function, that clarifies angles units

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -321,8 +321,9 @@ path startingPoint segments =
 circle, the radius of it, the start angle where the arc will start, the end
 angle where the arc will end, and if it should draw in clockwise or
 anti-clockwise direction.
+Angles must be in standard Elm angles (radians)
 
-    arc ( 10, 10 ) 40 { startAngle = 15, endAngle = 85, clockwise = True }
+    arc ( 10, 10 ) 40 { startAngle = degrees 15, endAngle = degrees 85, clockwise = True }
 
 -}
 arc : Point -> Float -> { startAngle : Float, endAngle : Float, clockwise : Bool } -> Shape


### PR DESCRIPTION
I wrote 'standard Elm angles' because that's the output of unit
conversion of Elm functions.

It happens to be radians that is what canvas uses. In case that this
changes maybe this function must do the conversion for the
CustomElementJsonApi::arc function to consume.

To show that degrees do not work: https://ellie-app.com/87wM3rFVkWFa1