### PR TITLE
Add an image smoothing setting

### DIFF
--- a/src/Canvas/Internal/CustomElementJsonApi.elm
+++ b/src/Canvas/Internal/CustomElementJsonApi.elm
@@ -6,7 +6,7 @@ module Canvas.Internal.CustomElementJsonApi exposing
     , beginPath, closePath, FillRule(..), fill, clip, stroke, arc, arcTo, bezierCurveTo, lineTo, moveTo, quadraticCurveTo, rect, circle
     , lineCap, lineDashOffset, lineJoin, lineWidth, miterLimit, setLineDash
     , shadowBlur, shadowColor, shadowOffsetX, shadowOffsetY
-    , globalAlpha, globalCompositeOperation, save, restore
+    , globalAlpha, globalCompositeOperation, globalImageSmoothingEnabled, save, restore
     , rotate, scale, translate, transform, setTransform
     , drawImage
     , Command, commands
@@ -64,7 +64,7 @@ better defaults as time goes by, and make specific tutorials with Elm.
 
 # Global Canvas settings
 
-@docs globalAlpha, globalCompositeOperation, save, restore
+@docs globalAlpha, globalCompositeOperation, globalImageSmoothingEnabled, save, restore
 
 
 # Global Canvas transforms
@@ -167,6 +167,13 @@ for more information and pictures of what each mode does.
 globalCompositeOperation : String -> Command
 globalCompositeOperation mode =
     field "globalCompositeOperation" (string mode)
+
+
+{-| Enable/disable smoothing of the canvas.
+-}
+globalImageSmoothingEnabled : Bool -> Command
+globalImageSmoothingEnabled enabled =
+    field "imageSmoothingEnabled" (bool enabled)
 
 
 {-| Determines how the end points of every line are drawn. See `LineCap` for the

--- a/src/Canvas/Settings/Advanced.elm
+++ b/src/Canvas/Settings/Advanced.elm
@@ -1,7 +1,7 @@
 module Canvas.Settings.Advanced exposing
     ( shadow, Shadow
     , transform, Transform(..), translate, rotate, scale, applyMatrix
-    , alpha, compositeOperationMode, GlobalCompositeOperationMode(..)
+    , alpha, smoothing, compositeOperationMode, GlobalCompositeOperationMode(..)
     )
 
 {-|
@@ -38,12 +38,12 @@ sensible defaults.
 @docs transform, Transform, translate, rotate, scale, applyMatrix
 
 
-## Alpha and global composite mode
+## Alpha, smoothing and global composite mode
 
 Finally, there are a couple of other settings that you can use to create
 interesting visual effects:
 
-@docs alpha, compositeOperationMode, GlobalCompositeOperationMode
+@docs alpha, smoothing, compositeOperationMode, GlobalCompositeOperationMode
 
 -}
 
@@ -226,6 +226,13 @@ See `GlobalCompositeOperationMode` below for more information.
 compositeOperationMode : GlobalCompositeOperationMode -> Setting
 compositeOperationMode mode =
     mode |> globalCompositeOperationModeToString |> CE.globalCompositeOperation |> SettingCommand
+
+
+{-| Specify if scaled images are smoothed (default) or not.
+-}
+smoothing : Bool -> Setting
+smoothing enabled =
+    SettingCommand (globalImageSmoothingEnabled enabled)
 
 
 


### PR DESCRIPTION
I've added a setting to be able to disable image smoothing, [as explained in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled).

When adding `Advanced.smoothing False` to `Canvas.texture [ ... ]` settings, the image smoothing is deactivated, which is very convenient for some image visualization tasks or pixel art stuff. One thing I didn't figure out with the API (I'm not very accustomed to it) is that this setting should only be set once for the canvas, not per texture.

Let me know what you think! And don't hesitate to pick names that better match your API if they don't fit well. Here are screenshot with `smoothing False` (first image) and without (second image).

![smooth-false](https://user-images.githubusercontent.com/2905865/114069046-da521800-989e-11eb-8d67-58af473244e7.png)
![smooth-true](https://user-images.githubusercontent.com/2905865/114069063-dde59f00-989e-11eb-9616-05c161b4e77f.png)

