### PR TITLE
Add Texture.fromCanvasImageSource

### DIFF
--- a/examples/LoadingImagesFromJs.elm
+++ b/examples/LoadingImagesFromJs.elm
@@ -56,7 +56,7 @@ init images =
     let
         textures =
             images
-                |> List.filterMap fromDomImage
+                |> List.filterMap (Result.toMaybe << fromCanvasImageSource)
     in
     ( ( 0, textures )
     , Cmd.none

--- a/src/Canvas/Internal/Texture.elm
+++ b/src/Canvas/Internal/Texture.elm
@@ -3,6 +3,7 @@ module Canvas.Internal.Texture exposing
     , Source(..)
     , Sprite
     , Texture(..)
+    , decodeCanvasImageSource
     , decodeImageLoadEvent
     , decodeTextureImage
     , drawTexture
@@ -58,6 +59,24 @@ decodeTextureImage =
                             Nothing
                     )
                     (D.field "tagName" D.string)
+                    (D.field "width" D.float)
+                    (D.field "height" D.float)
+            )
+
+
+decodeCanvasImageSource : D.Decoder Texture
+decodeCanvasImageSource =
+    D.value
+        |> D.andThen
+            (\image ->
+                D.map2
+                    (\width height ->
+                        TImage
+                            { json = image
+                            , width = width
+                            , height = height
+                            }
+                    )
                     (D.field "width" D.float)
                     (D.field "height" D.float)
             )

--- a/src/Canvas/Texture.elm
+++ b/src/Canvas/Texture.elm
@@ -1,6 +1,6 @@
 module Canvas.Texture exposing
     ( Source, loadFromImageUrl
-    , fromDomImage
+    , fromCanvasImageSource, fromDomImage
     , Texture
     , sprite
     , dimensions
@@ -22,7 +22,7 @@ You can load textures by using `toHtmlWith`, and use them to draw with
 
 ## From existing sources
 
-@docs fromDomImage
+@docs fromCanvasImageSource, fromDomImage
 
 
 # Texture types
@@ -103,6 +103,8 @@ dimensions texture =
 
 {-| Make a `Texture` from a DOM image.
 
+**DEPRECATED**. Use `fromCanvasImageSource` instead.
+
 For example, if you want to make textures out of images you loaded yourself in
 JS and passed to Elm via ports or flags, you would use this method.
 
@@ -115,3 +117,16 @@ fromDomImage value =
     D.decodeValue T.decodeTextureImage value
         |> Result.toMaybe
         |> Maybe.andThen identity
+
+
+{-| Make a `Texture` from a `CanvasImageSource` received from JS via ports or flags.
+
+This could for example be an `HTMLImageElement`, an `SVGImageElement`, or an `ImageBitmap`.
+
+Decoding will fail if the `Json.Decode.Value` does not have both `width` and
+`height` fields with float values.
+
+-}
+fromCanvasImageSource : D.Value -> Result D.Error Texture
+fromCanvasImageSource value =
+    D.decodeValue T.decodeCanvasImageSource value


### PR DESCRIPTION
The CanvasRenderingContext2D.drawImage() method accepts
any object implementing the CanvasImageSource interface.
This libray uses Canvas.Texture to represent such objects.

Currently this library provides Texture.fromDomImage to create a Texture
from an HTMLImageElement. fromDomImage however enforces that
image.tagName == "IMG" meaning it cannot be used for any of the other
interfaces that browsers accept as an CanvasImageSource like:

* SVGImageElement
* HTMLVideoElement
* HTMLCanvasElement
* ImageBitmap
* OffscreenCanvas

This commit therefore introduces a new Texture.fromCanvasImageSource
function that essentially does the same as Texture.fromDomImage but
without enforcing a tagName. Since this makes the fromDomImage function
redundant this commit also deprecates it.