### PR TITLE
Added roundRect support

### DIFF
--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -3,7 +3,7 @@ module Canvas exposing
     , Renderable, Point
     , clear, shapes, text, texture, group
     , Shape
-    , rect, circle, arc, path
+    , rect, roundRect, circle, arc, path
     , PathSegment, arcTo, bezierCurveTo, lineTo, moveTo, quadraticCurveTo
     )
 
@@ -36,7 +36,7 @@ a `Shape`, which you can feed to `shapes` to get something on the screen.
 
 Here are the different functions that produce shapes that we can draw.
 
-@docs rect, circle, arc, path
+@docs rect, roundRect, circle, arc, path
 
 
 ## Paths
@@ -322,6 +322,20 @@ corner, the width, and the height.
 rect : Point -> Float -> Float -> Shape
 rect pos width height =
     Rect pos width height
+
+
+{-| Creates the shape of a rounded rectangle.
+
+It takes the position of the top left corner, the width, the height and a list specifying
+the radii of the circular arc to be used for the corners of the rectangle. The list must
+contain between 1 and 4 positive numbers.
+
+You can find more info on this [page](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect).
+
+-}
+roundRect : Point -> Float -> Float -> List Float -> Shape
+roundRect pos width height radii =
+    RoundRect pos width height radii
 
 
 {-| Creates a circle. It takes the position of the center of the circle, and the
@@ -615,6 +629,9 @@ renderShape shape cmds =
     case shape of
         Rect ( x, y ) w h ->
             CE.rect x y w h :: CE.moveTo x y :: cmds
+
+        RoundRect ( x, y ) w h r ->
+            CE.roundRect x y w h r :: CE.moveTo x y :: cmds
 
         Circle ( x, y ) r ->
             CE.circle x y r :: CE.moveTo (x + r) y :: cmds

--- a/src/Canvas/Internal/Canvas.elm
+++ b/src/Canvas/Internal/Canvas.elm
@@ -54,6 +54,7 @@ type alias Text =
 
 type Shape
     = Rect Point Float Float
+    | RoundRect Point Float Float (List Float)
     | Circle Point Float
     | Path Point (List PathSegment)
     | Arc Point Float Float Float Bool

--- a/src/Canvas/Internal/CustomElementJsonApi.elm
+++ b/src/Canvas/Internal/CustomElementJsonApi.elm
@@ -9,7 +9,7 @@ module Canvas.Internal.CustomElementJsonApi exposing
     , globalAlpha, globalCompositeOperation, globalImageSmoothingEnabled, save, restore
     , rotate, scale, translate, transform, setTransform
     , drawImage
-    , Command, commands
+    , Command, commands, roundRect
     )
 
 {-| This module exposes a low level drawing API to work with the DOM canvas.
@@ -672,6 +672,15 @@ this rectangle. [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Canv
 rect : Float -> Float -> Float -> Float -> Command
 rect x y w h =
     fn "rect" [ float x, float y, float w, float h ]
+
+
+{-| Adds a rounded rectangle to the current path.
+The radii of the corners can be specified in much the same way as the CSS border-radius property.
+[MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect)
+-}
+roundRect : Float -> Float -> Float -> Float -> List Float -> Command
+roundRect x y w h r =
+    fn "roundRect" [ float x, float y, float w, float h, Encode.list float r ]
 
 
 {-| Restores the most recently saved canvas state by popping the top entry in


### PR DESCRIPTION
Hi,

This is a pull request that exposes the new roundRect method.

As it is not currently supported on firefox I was wondering if we should add a warning in the usage section of the readme to link to a polyfill such as [this one](https://github.com/Kaiido/roundRect)